### PR TITLE
Fix warnings about using act

### DIFF
--- a/src/use-debounce/use-debounce.test.tsx
+++ b/src/use-debounce/use-debounce.test.tsx
@@ -1,10 +1,16 @@
 import 'jest-dom/extend-expect';
 import * as React from 'react';
-import { render, cleanup, fireEvent } from 'react-testing-library';
+import { render, cleanup, fireEvent, act } from 'react-testing-library';
 import { useDebounce } from './';
 import { useInput } from '../use-input';
 
 afterEach(cleanup);
+
+const advanceByTime = (time: number): void => {
+  act(() => {
+    jest.advanceTimersByTime(time);
+  });
+};
 
 const TestComponent = ({ delay }: { delay: number }): JSX.Element => {
   const input = useInput('');
@@ -31,12 +37,12 @@ it('should debounce a value and only update once within the given delay', () => 
     }, 50 * (index + 1));
   });
 
-  jest.advanceTimersByTime(100);
+  advanceByTime(100);
   expect(debouncedValue).toHaveTextContent('');
 
-  jest.advanceTimersByTime(100);
+  advanceByTime(100);
   expect(debouncedValue).toHaveTextContent('');
 
-  jest.advanceTimersByTime(100);
+  advanceByTime(100);
   expect(debouncedValue).toHaveTextContent('abc');
 });

--- a/src/use-interval/use-interval.test.tsx
+++ b/src/use-interval/use-interval.test.tsx
@@ -1,9 +1,15 @@
 import 'jest-dom/extend-expect';
 import * as React from 'react';
-import { render, cleanup, fireEvent } from 'react-testing-library';
+import { render, cleanup, fireEvent, act } from 'react-testing-library';
 import { useInterval } from './';
 
 afterEach(cleanup);
+
+const advanceByTime = (time: number): void => {
+  act(() => {
+    jest.advanceTimersByTime(time);
+  });
+};
 
 interface Props {
   initialCount?: number;
@@ -57,10 +63,10 @@ it('should run an interval', () => {
 
   expect(count).toHaveTextContent('1');
 
-  jest.advanceTimersByTime(1000);
+  advanceByTime(1000);
   expect(count).toHaveTextContent('2');
 
-  jest.advanceTimersByTime(1000);
+  advanceByTime(1000);
   expect(count).toHaveTextContent('3');
 });
 
@@ -70,7 +76,7 @@ it('should be pausable', () => {
 
   expect(count).toHaveTextContent('1');
   fireEvent.click(pause);
-  jest.advanceTimersByTime(2000);
+  advanceByTime(2000);
   expect(count).toHaveTextContent('1');
 });
 
@@ -81,10 +87,11 @@ it('should be possible to adjust interval speed', () => {
   expect(count).toHaveTextContent('1');
 
   fireEvent.change(delay, { target: { value: '500' } });
-  jest.advanceTimersByTime(500);
+  advanceByTime(500);
   expect(count).toHaveTextContent('2');
 
   fireEvent.change(delay, { target: { value: '5000' } });
-  jest.advanceTimersByTime(10000);
+  advanceByTime(5000);
+  advanceByTime(5000);
   expect(count).toHaveTextContent('4');
 });

--- a/src/use-online/use-online.test.tsx
+++ b/src/use-online/use-online.test.tsx
@@ -1,6 +1,6 @@
 import 'jest-dom/extend-expect';
 import * as React from 'react';
-import { render, cleanup } from 'react-testing-library';
+import { render, cleanup, fireEvent } from 'react-testing-library';
 import { useOnline } from './';
 
 afterEach(cleanup);
@@ -16,7 +16,7 @@ it('should determine if a client is online or not', () => {
   expect(getByText('online')).toBeInTheDocument();
 
   const evt = new Event('offline', { bubbles: true });
-  window.dispatchEvent(evt);
+  fireEvent(window, evt);
 
   expect(getByText('offline')).toBeInTheDocument();
 });

--- a/src/use-scroll-position/use-scroll-position.test.tsx
+++ b/src/use-scroll-position/use-scroll-position.test.tsx
@@ -1,6 +1,6 @@
 import 'jest-dom/extend-expect';
 import * as React from 'react';
-import { render, cleanup } from 'react-testing-library';
+import { render, cleanup, fireEvent } from 'react-testing-library';
 import { useScrollPosition } from '../use-scroll-position';
 
 afterEach(cleanup);
@@ -24,7 +24,7 @@ it('should track scroll position', () => {
   Object.defineProperty(window, 'pageXOffset', { value: 100 });
   Object.defineProperty(window, 'pageYOffset', { value: 100 });
   const scrollEv = new Event('scroll');
-  window.dispatchEvent(scrollEv);
+  fireEvent(window, scrollEv);
 
   expect(getByText(/x: \d+/)).toHaveTextContent('x: 100');
   expect(getByText(/y: \d+/)).toHaveTextContent('y: 100');
@@ -37,7 +37,7 @@ it('should accept an optional throttle wrapper', () => {
   render(<TestComponent throttle={throttle} />);
 
   const scrollEv = new Event('scroll');
-  window.dispatchEvent(scrollEv);
+  fireEvent(window, scrollEv);
 
   expect(window.requestAnimationFrame).toHaveBeenCalled();
 });


### PR DESCRIPTION
Wrapped all setState calls in appropriate functions using act. The only onw not working is
use-promise since act doesn't cover async actions yet. Will follow up on that.